### PR TITLE
Wagtail React explorer linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
     'prefer-template': [0],
     'quote-props': ['error', 'consistent-as-needed'],
     'react/jsx-boolean-value': [0],
-    'react/jsx-indent-props': [2, 4],
+    'react/jsx-indent-props': [2, 2],
     'react/jsx-no-bind': [0],
     'react/prefer-es6-class': [0, 'never'],
     'react/sort-comp': [0],

--- a/index.js
+++ b/index.js
@@ -21,4 +21,7 @@ module.exports = {
     'react/prefer-es6-class': [0, 'never'],
     'react/sort-comp': [0],
   },
+  env: {
+    mocha: true,
+  }
 };


### PR DESCRIPTION
Here are minor changes that are necessary for the work I'm doing in https://github.com/torchbox/wagtail/pull/3012 to pass the linting :)
- `'react/jsx-indent-props': [2, 2],` is simply reflecting the fact that we use 2 spaces for indentation.
- the mocha env is added for `describe` and `it` declarations to be (safely) ignored.
