### PR TITLE
Disable no-warning-comments and react/prop-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,7 @@ module.exports = {
     'no-multi-spaces': ['off'],
     'no-new': ['warn'],
     'no-var': ['off'],
-    'no-warning-comments': [
-      'warn',
-      { terms: ['todo', 'fixme', 'xxx'], location: 'start' },
-    ],
+    'no-warning-comments': ['off'],
     'object-shorthand': ['error', 'methods'],
     'prefer-arrow-callback': ['warn'],
     'prefer-template': ['off'],
@@ -28,5 +25,6 @@ module.exports = {
     'react/jsx-no-bind': ['off'],
     'react/prefer-es6-class': ['off', 'never'],
     'react/sort-comp': ['off'],
+    'react/prop-types': ['off'],
   },
 };


### PR DESCRIPTION
In the core team meeting on 14th April 2021, we agreed to disable the following ESlint rules

- `no-warning-comments` - This warns us for writing comments that begin with "TODO"/"FIXME"/etc. We think these comments can be helpful to keep in the code so having them as a warning would add noise to the build and cause actual new warnings to be missed.
- `react/prop-types` - We're moving towards replacing prop types with TypeScript instead so this is no longer required