### PR TITLE
add print-config npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint:js": "eslint ./ --max-warnings 0 --ignore-pattern 'examples'",
     "lint": "npm run lint:format && npm run lint:js",
     "preflight": "npm run format && npm run lint && npm run test",
+    "print-config": "eslint --print-config .eslintrc",
     "test": "jest"
   },
   "prettier": {


### PR DESCRIPTION
I find myself adding this often when wanting check the full output - thought it would be nice to include this script by default.