### PR TITLE
Add `no-constant-binary-expression` to rules to catch common bugs

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -18,9 +18,9 @@ describe('linting', () => {
   });
 
   it('flags warnings when invalid', async () => {
-    const lintResult = await eslint.lintText(invalidExample);
-    expect(lintResult[0].errorCount + lintResult[0].warningCount).not.toEqual(
-      0,
-    );
+    const [{ errorCount, warningCount }] =
+      await eslint.lintText(invalidExample);
+
+    expect(errorCount + warningCount).toEqual(2);
   });
 });

--- a/examples/invalid.js
+++ b/examples/invalid.js
@@ -1,1 +1,1 @@
-const foo = 'foo';
+const foo = 'foo' || '';

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     ],
     // See https://github.com/wagtail/wagtail/pull/9483.
     'max-classes-per-file': 'off',
+    'no-constant-binary-expression': 'error',
     'no-new': ['warn'],
     'no-var': ['off'],
     'no-warning-comments': ['off'],


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-constant-binary-expression

Examples of common bugs that can be found https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/

This also flags a bug with the Wagtail code, while not sinister, would be good to have this kind of thing flagged.

https://github.com/wagtail/wagtail/blob/771e83802ab3e09e898885d3b96ef4a15ba669d9/client/src/components/Minimap/Minimap.tsx#L41

Observe we are doing an or check against a string that will never be empty, so this fallback to an empty string will never happen.