### PR TITLE
Use assert: either for jsx-a11y/label-has-associated-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ With some Wagtail-specific customizations:
 | [`jsx-a11y/iframe-has-title`][94]                                  | `error`  |                                                                           |
 | [`jsx-a11y/img-redundant-alt`][95]                                 | `error`  |                                                                           |
 | [`jsx-a11y/interactive-supports-focus`][96]                        | `error`  | [see Config][config]                                                      |
-| [`jsx-a11y/label-has-associated-control`][97]                      | `error`  | `{"assert":"both","depth":25}`                                            |
+| [`jsx-a11y/label-has-associated-control`][97]                      | `error`  | `{"assert":"either","depth":25}`                                          |
 | [`jsx-a11y/lang`][98]                                              | `error`  |                                                                           |
 | [`jsx-a11y/media-has-caption`][99]                                 | `error`  |                                                                           |
 | [`jsx-a11y/mouse-events-have-key-events`][100]                     | `error`  |                                                                           |

--- a/__tests__/rules.test.mjs.snapshot
+++ b/__tests__/rules.test.mjs.snapshot
@@ -412,7 +412,7 @@ exports[`rules snapshot > has stable config rules 1`] = `
     "jsx-a11y/label-has-associated-control": [
       "error",
       {
-        "assert": "both",
+        "assert": "either",
         "depth": 25
       }
     ],

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ export default defineConfig(
       'jsx-a11y/label-has-associated-control': [
         'error',
         {
-          assert: 'both',
+          assert: 'either',
           depth: 25,
         },
       ],


### PR DESCRIPTION
Was reviewing https://github.com/wagtail/wagtail/pull/13379 and wondered why we got issues for this rule...

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->
It doesn't make sense to assert both nesting and "for" attribute. In Wagtail, we use both patterns depending on our use case, and nesting the control inside the label isn't always feasible.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None